### PR TITLE
Compatibilité PHP 7 + infos paramétrage ldap

### DIFF
--- a/experimentation/front-agimus-ng/config/config-sample.php
+++ b/experimentation/front-agimus-ng/config/config-sample.php
@@ -36,6 +36,7 @@
     $LDAP['BASE_DN'] = "dc=univ,dc=fr";
     $LDAP['PEOPLE_BASE_DN'] = "ou=people,".$LDAP['BASE_DN'];
     $LDAP['PEOPLE_ATTRS'] = array("uid", "mail",  "group");
+	// saisir les attributs en minuscule !!!
     $LDAP['GROUP_ATTRS'] = "group";
 
 


### PR DESCRIPTION
- Config.php :
Ajout d'une information sur le paramétrage LDAP pour éviter des erreurs liées aux majuscules dans les attributs ($LDAP['GROUP_ATTRS']).

- Controller.php : 
Remplacement de mysql_ (obsolète depuis php 5.5.x, supprimé dans php7) par mysqli_ (nécessite php>5.0.0 et mysql>4.1.13).
